### PR TITLE
feat: Add '.' separator for number presentation

### DIFF
--- a/src/pages/DetailsCountry/index.js
+++ b/src/pages/DetailsCountry/index.js
@@ -18,6 +18,7 @@ import {
 
 import GoBack from "../../components/GoBack";
 import SubTitle from "../../components/SubTitle";
+import numberFormatter from '../../utils/formatter'
 
 export default DetailsCountry = () => {
   const route = useRoute();
@@ -44,12 +45,12 @@ export default DetailsCountry = () => {
 
             <CardCases>
               <CardInfo>
-                <CardNumber>{detail.TotalConfirmed}</CardNumber>
+                <CardNumber>{numberFormatter(detail.TotalConfirmed)}</CardNumber>
                 <CardDescription>Acumulados</CardDescription>
               </CardInfo>
 
               <CardInfo>
-                <CardNumber>{detail.NewConfirmed}</CardNumber>
+                <CardNumber>{numberFormatter(detail.NewConfirmed)}</CardNumber>
                 <CardDescription>Registros novos</CardDescription>
               </CardInfo>
             </CardCases>
@@ -60,12 +61,12 @@ export default DetailsCountry = () => {
 
             <CardCases>
               <CardInfo>
-                <CardNumber>{detail.TotalDeaths}</CardNumber>
+                <CardNumber>{numberFormatter(detail.TotalDeaths)}</CardNumber>
                 <CardDescription>Acumulados</CardDescription>
               </CardInfo>
 
               <CardInfo>
-                <CardNumber>{detail.NewDeaths}</CardNumber>
+                <CardNumber>{numberFormatter(detail.NewDeaths)}</CardNumber>
                 <CardDescription>Registros novos</CardDescription>
               </CardInfo>
             </CardCases>
@@ -76,12 +77,12 @@ export default DetailsCountry = () => {
 
             <CardCases>
               <CardInfo>
-                <CardNumber>{detail.TotalRecovered}</CardNumber>
+                <CardNumber>{numberFormatter(detail.TotalRecovered)}</CardNumber>
                 <CardDescription>Acumulados</CardDescription>
               </CardInfo>
 
               <CardInfo>
-                <CardNumber>{detail.NewRecovered}</CardNumber>
+                <CardNumber>{numberFormatter(detail.NewRecovered)}</CardNumber>
                 <CardDescription>Registros novos</CardDescription>
               </CardInfo>
             </CardCases>

--- a/src/pages/Global/index.js
+++ b/src/pages/Global/index.js
@@ -18,6 +18,7 @@ import {
 
 import GoBack from "../../components/GoBack";
 import SubTitle from "../../components/SubTitle";
+import numberFormatter from '../../utils/formatter'
 
 export default Global = () => {
   const route = useRoute();
@@ -44,12 +45,12 @@ export default Global = () => {
 
             <CardCases>
               <CardInfo>
-                <CardNumber>{global.TotalConfirmed}</CardNumber>
+                <CardNumber>{numberFormatter(global.TotalConfirmed)}</CardNumber>
                 <CardDescription>Acumulados</CardDescription>
               </CardInfo>
 
               <CardInfo>
-                <CardNumber>{global.NewConfirmed}</CardNumber>
+                <CardNumber>{numberFormatter(global.NewConfirmed)}</CardNumber>
                 <CardDescription>Registros novos</CardDescription>
               </CardInfo>
             </CardCases>
@@ -60,12 +61,12 @@ export default Global = () => {
 
             <CardCases>
               <CardInfo>
-                <CardNumber>{global.TotalDeaths}</CardNumber>
+                <CardNumber>{numberFormatter(global.TotalDeaths)}</CardNumber>
                 <CardDescription>Acumulados</CardDescription>
               </CardInfo>
 
               <CardInfo>
-                <CardNumber>{global.NewDeaths}</CardNumber>
+                <CardNumber>{numberFormatter(global.NewDeaths)}</CardNumber>
                 <CardDescription>Registros novos</CardDescription>
               </CardInfo>
             </CardCases>
@@ -76,12 +77,12 @@ export default Global = () => {
 
             <CardCases>
               <CardInfo>
-                <CardNumber>{global.TotalRecovered}</CardNumber>
+                <CardNumber>{numberFormatter(global.TotalRecovered)}</CardNumber>
                 <CardDescription>Acumulados</CardDescription>
               </CardInfo>
 
               <CardInfo>
-                <CardNumber>{global.NewRecovered}</CardNumber>
+                <CardNumber>{numberFormatter(global.NewRecovered)}</CardNumber>
                 <CardDescription>Registros novos</CardDescription>
               </CardInfo>
             </CardCases>

--- a/src/utils/formatter.js
+++ b/src/utils/formatter.js
@@ -1,0 +1,5 @@
+const numberFormatter = (value) => {
+  return value.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ".");
+};
+
+export default numberFormatter;


### PR DESCRIPTION
Added a dot separator for number data presentation

<h4 align="center">
 <img alt="Global" title="#global" width="250px" src="https://user-images.githubusercontent.com/11820690/82339781-cec6db80-99c4-11ea-8537-6cc616554832.jpg">
 <img alt="Brazil" title="#brazil" width="250px" src="https://user-images.githubusercontent.com/11820690/82339776-cd95ae80-99c4-11ea-9dfb-84229143fbf3.jpg">
</h4>